### PR TITLE
feat: output frontend build to backend public folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ npm run dev
 cd frontend
 npm ci
 npm run dev
+# Build para produção
+npm run build  # gera arquivos estáticos em ../httpdocs/backend/public
 ```
 
 Acesse http://localhost:3333/api/health para checar a API e banco de dados.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // Durante o dev, proxy para backend local:
 export default defineConfig({
@@ -14,6 +15,8 @@ export default defineConfig({
     }
   },
   build: {
-    outDir: 'dist'
+    // Produz build no backend para ser servido pelo Express
+    outDir: path.resolve(__dirname, '../httpdocs/backend/public'),
+    emptyOutDir: true
   }
 })

--- a/httpdocs/backend/public/.gitignore
+++ b/httpdocs/backend/public/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- build frontend assets directly to backend public directory
- document production build step
- ignore generated assets in backend public folder

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd7251cc8330ba4f39b964549728