### PR TITLE
chore: add deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Acesse http://localhost:3333/api/health para checar a API e banco de dados.
 O build do frontend é servido a partir de `httpdocs/backend/public`.
 
 Deploy é realizado via GitHub Actions (CI/CD) enviando arquivos via FTP para o Plesk.
+
+## Deploy
+
+Scripts em `deploy/` auxiliam na publicação:
+
+- `deploy.sh` – compila o frontend, sincroniza com o backend e gera sitemaps.
+- `auto-update.sh` – busca novos commits no branch (padrão `main`) e roda `deploy.sh` quando há mudanças.
+- `deploy-plesk.sh` – para ambientes Plesk, constrói o frontend e copia o resultado para `httpdocs/`.
+
+Execute `deploy/deploy.sh` manualmente após cada alteração ou agende `deploy/auto-update.sh` em um cron. Em hospedagens estáticas, utilize `deploy/deploy-plesk.sh`.
+

--- a/deploy/auto-update.sh
+++ b/deploy/auto-update.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH="${1:-main}"
+REMOTE="${2:-origin}"
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+cd "$ROOT_DIR"
+LOCAL_HASH=$(git rev-parse "$BRANCH")
+REMOTE_HASH=$(git ls-remote "$REMOTE" "$BRANCH" | awk '{print $1}')
+
+if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
+  git pull --ff-only "$REMOTE" "$BRANCH"
+  "$ROOT_DIR/deploy/deploy.sh"
+fi

--- a/deploy/deploy-plesk.sh
+++ b/deploy/deploy-plesk.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+TARGET_DIR="$ROOT_DIR/httpdocs"
+
+npm --prefix "$FRONTEND_DIR" ci
+npm --prefix "$FRONTEND_DIR" run build
+
+rm -rf "$TARGET_DIR"/*
+cp -r "$FRONTEND_DIR/dist"/* "$TARGET_DIR/"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+BACKEND_DIR="$ROOT_DIR/httpdocs/backend"
+
+# Build frontend
+npm --prefix "$FRONTEND_DIR" run build
+
+# If frontend/dist exists, sync it to backend/public
+if [ -d "$FRONTEND_DIR/dist" ]; then
+  rm -rf "$BACKEND_DIR/public"
+  cp -r "$FRONTEND_DIR/dist" "$BACKEND_DIR/public"
+fi
+
+# Generate sitemaps
+npm --prefix "$BACKEND_DIR" run sitemap


### PR DESCRIPTION
## Summary
- add deploy scripts for building frontend, syncing backend and generating sitemaps
- add auto-update script to pull changes and redeploy
- add Plesk deployment script and document usage

## Testing
- `bash -n deploy/deploy.sh`
- `bash -n deploy/auto-update.sh`
- `bash -n deploy/deploy-plesk.sh`
- `npm test --prefix frontend` (fails: Missing script: "test")
- `npm test --prefix httpdocs/backend` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c1d0b19a708330a6e5858c8ee8e81f